### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add the configuration in `app/config/config.yml`
 ```yml
 lionware_symfony_session_timeout:
     session:
-        expiration_time: %novamedia_session_expiration_time%
+        expiration_time: "%novamedia_session_expiration_time%"
 ```
 
 ## Notes


### PR DESCRIPTION
Quoted %novamedia_session_expiration_time% as it will throw an error in Symfony 4.0. From the profiler "User Deprecated: Not quoting the scalar "%novamedia_session_expiration_time%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0. "