### PR TITLE
Fixing deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 phpunit.xml
+.idea/

--- a/src/Lionware/SymfonySessionTimeoutBundle/DependencyInjection/Configuration.php
+++ b/src/Lionware/SymfonySessionTimeoutBundle/DependencyInjection/Configuration.php
@@ -13,8 +13,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('lionware_symfony_session_timeout');
+        $treeBuilder = new TreeBuilder('lionware_symfony_session_timeout');
+        $rootNode = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('lionware_symfony_session_timeout');
 
         $rootNode->children()
             ->arrayNode('session')->isRequired()->children()


### PR DESCRIPTION
Symfony 4 brings some deprecation warnings about the usage of `TreeBuilder::root()` ([check this blog](https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes))

This PR fix those deprecations using the new API when available. Maybe next week i'll be making the recipe and docs update. 