### PR TITLE
Support for symfony version 2.0 and up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=5.3.9",
-    "symfony/framework-bundle": "~2.0|~3.0|~4.0"
+    "symfony/framework-bundle": ">=2.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This would be compatible with all Symfony version. Defaulting on 2.0 and up will prevent needing to update the configuration. Bundle is so simple I presume it will be always compatible.